### PR TITLE
fix: properly and consistently handle variable subsets with things like "$foo" and "$foobar"

### DIFF
--- a/conf/parse_test.go
+++ b/conf/parse_test.go
@@ -47,14 +47,19 @@ func TestExpand(t *testing.T) {
 				"foo":    "this is not really expected but I'm not sure how it should be handled ",
 				"foobar": "it's a miracle",
 			},
-			expected: "this is not really expected but I'm not sure how it should be handled bar",
+			expected: "it's a miracle",
 		},
 	}
 
 	for _, c := range cases {
 		t.Run(c.input, func(t *testing.T) {
 			parseContext := parseContext{
-				variables: c.variables,
+				variables:           map[string]string{},
+				sortedVariableNames: []string{},
+			}
+
+			for name, value := range c.variables {
+				parseContext.setVariable(name, value)
 			}
 
 			actual := parseContext.expand(c.input)
@@ -145,9 +150,9 @@ func TestParseString(t *testing.T) {
 			input: `
 			var foo = bar
 			var bar = $foo$foo$foo$foo
-			var laughs = $bar$bar$bar$bar
+			var foobar = $bar$bar$bar$bar
 
-			set webhook = $laughs
+			set webhook = $foobar
 			`,
 			expected: ParsedConf{
 				WebhookURL: "barbarbarbarbarbarbarbarbarbarbarbarbarbarbarbar",

--- a/conf/sort_by_length.go
+++ b/conf/sort_by_length.go
@@ -1,0 +1,15 @@
+package conf
+
+type variablesByLength []string
+
+func (v variablesByLength) Len() int {
+	return len(v)
+}
+
+func (v variablesByLength) Swap(i int, j int) {
+	v[i], v[j] = v[j], v[i]
+}
+
+func (v variablesByLength) Less(i int, j int) bool {
+	return len(v[i]) > len(v[j])
+}

--- a/conf/symbols.go
+++ b/conf/symbols.go
@@ -25,7 +25,7 @@ func parseVar(line string, parseContext *parseContext) (bool, error) {
 	value := matches[2]
 	value = parseContext.expand(value) // something something billion laughs attack
 
-	parseContext.variables[name] = value
+	parseContext.setVariable(name, value)
 
 	return true, nil
 }


### PR DESCRIPTION
Previously we just looped over the raw map which was never in the correct order, but was
even inconsistent sometimes - tests would pass, tests would fail.
This commit replaces longer variable names first which should cover all previously-affected
cases.