### PR TITLE
Convert mediainfo.MediaInfo into an injectable config script usable by conf.Parse

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ go test ./...
 - [ ] when given a source video url, download it
 - [x] when given a source video path, extract metadata like width, length, etc: [mediainfo](mediainfo)
 - [x] parse a config file into something machine-readable
-- [ ] shove source video metadata into config file vars
+- [x] shove source video metadata into config file vars
 - [ ] working `if` statements in config file
 - [ ] somehow handle "secondary url options" like `, metadata=true`, `, number=6`, etc
 - [ ] post with-metadata and without-metadata webhooks on state changes

--- a/mediainfovars/.snapshots/TestSnapshotConvertToConfigurationVariables-ConvertToConfigurationVariables_snapshot_0
+++ b/mediainfovars/.snapshots/TestSnapshotConvertToConfigurationVariables-ConvertToConfigurationVariables_snapshot_0
@@ -1,0 +1,16 @@
+var source_mime_type = video/mp4
+var source_size = 204141
+var source_width = 640
+var source_height = 360
+var source_aspect_ratio = 16:9
+var source_fps = 3823232/127989
+var source_video_bitrate = 276883
+var source_is_hd = false
+var source_is_audio_only = false
+var source_duration = 4.285011
+var source_video_codec = h264
+var source_audio_codec = aac
+var source_channels = 2
+var source_audio_bitrate = 95999
+var source_sample_rate = 44100
+

--- a/mediainfovars/README.md
+++ b/mediainfovars/README.md
@@ -1,0 +1,67 @@
+# creamy-transcode/mediainfovars
+
+Convert `mediainfo.MediaInfo` structs into a config script that can be parsed by `conf.Parse`.
+
+## Usage
+
+```golang
+package main
+
+import (
+	"fmt"
+
+	"github.com/AlbinoDrought/creamy-transcode/conf"
+	"github.com/AlbinoDrought/creamy-transcode/mediainfo"
+	"github.com/AlbinoDrought/creamy-transcode/mediainfovars"
+	"github.com/davecgh/go-spew/spew"
+)
+
+func main() {
+  // get mediainfo.MediaInfo from a local file
+	result, _ := mediainfo.IdentifyFile("./mediainfo/ffprobe/test_fixtures/doggo_waddling.mp4")
+
+  // convert it to a config script
+	script := mediainfovars.ConvertToConfigurationVariables(result)
+	fmt.Println(script)
+
+  // our script which uses some converted variables like $source_width
+	myScript := `
+	set source = https://creamy-videos.r.albinodrought.com/static/videos/1.mov
+
+	var output_file_name = transcoded_$source_widthx$source_height.mp4
+
+	-> mp4 = https://creamy-videos.r.albinodrought.com/api/upload?size=$source_size&name=$output_file_name
+	`
+
+  // parse our merged script with conf.ParseString
+	parsedScript, _ := conf.ParseString(script + myScript)
+	spew.Dump(parsedScript)
+}
+
+// output:
+/*
+var source_mime_type = video/mp4
+var source_size = 204141
+var source_width = 640
+var source_height = 360
+var source_aspect_ratio = 16:9
+var source_fps = 3823232/127989
+var source_video_bitrate = 276883
+var source_is_hd = false
+var source_is_audio_only = false
+var source_duration = 4.285011
+var source_video_codec = h264
+var source_audio_codec = aac
+var source_channels = 2
+var source_audio_bitrate = 95999
+var source_sample_rate = 44100
+
+(conf.ParsedConf) {
+ SourceURL: (string) (len=61) "https://creamy-videos.r.albinodrought.com/static/videos/1.mov",
+ WebhookURL: (string) "",
+ Outputs: (map[string]string) (len=1) {
+  (string) (len=3) "mp4": (string) (len=92) "https://creamy-videos.r.albinodrought.com/api/upload?size=204141&name=transcoded_640x360.mp4"
+ }
+}
+*/
+```

--- a/mediainfovars/mediainfovars.go
+++ b/mediainfovars/mediainfovars.go
@@ -1,0 +1,41 @@
+package mediainfovars
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/AlbinoDrought/creamy-transcode/mediainfo"
+)
+
+type mappedSourceVar struct {
+	name  string
+	value interface{}
+}
+
+func ConvertToConfigurationVariables(info mediainfo.MediaInfo) string {
+	sourceVars := []mappedSourceVar{
+		{"mime_type", info.MimeType},
+		{"size", info.Size},
+		{"width", info.Width},
+		{"height", info.Height},
+		{"aspect_ratio", info.AspectRatio},
+		{"fps", info.FPS},
+		{"video_bitrate", info.VideoBitrate},
+		{"is_hd", info.IsHD},
+		{"is_audio_only", info.IsAudioOnly},
+		{"duration", info.Duration},
+		{"video_codec", info.VideoCodec},
+		{"audio_codec", info.AudioCodec},
+		{"channels", info.Channels},
+		{"audio_bitrate", info.AudioBitrate},
+		{"sample_rate", info.SampleRate},
+	}
+
+	var sb strings.Builder
+
+	for _, sourceVar := range sourceVars {
+		sb.WriteString(fmt.Sprintf("var source_%v = %v\n", sourceVar.name, sourceVar.value))
+	}
+
+	return sb.String()
+}

--- a/mediainfovars/mediainfovars_test.go
+++ b/mediainfovars/mediainfovars_test.go
@@ -1,0 +1,54 @@
+package mediainfovars
+
+import (
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/AlbinoDrought/creamy-transcode/conf"
+
+	"github.com/AlbinoDrought/creamy-transcode/mediainfo"
+
+	"github.com/bradleyjkemp/cupaloy"
+)
+
+var mediaInfos = []mediainfo.MediaInfo{
+	mediainfo.MediaInfo{
+		MimeType:     "video/mp4",
+		Size:         204141,
+		Width:        640,
+		Height:       360,
+		AspectRatio:  "16:9",
+		FPS:          "3823232/127989",
+		VideoBitrate: "276883",
+		IsHD:         false,
+		IsAudioOnly:  false,
+		Duration:     "4.285011",
+		VideoCodec:   "h264",
+		AudioCodec:   "aac",
+		Channels:     2,
+		AudioBitrate: "95999",
+		SampleRate:   "44100",
+	},
+}
+
+func TestSnapshotConvertToConfigurationVariables(t *testing.T) {
+	for i, mediaInfo := range mediaInfos {
+		t.Run("ConvertToConfigurationVariables snapshot "+strconv.Itoa(i), func(t *testing.T) {
+			script := ConvertToConfigurationVariables(mediaInfo)
+			cupaloy.SnapshotT(t, script)
+		})
+	}
+}
+
+func TestParsesSuccessfully(t *testing.T) {
+	for i, mediaInfo := range mediaInfos {
+		t.Run("ConvertToConfigurationVariables parse "+strconv.Itoa(i), func(t *testing.T) {
+			script := ConvertToConfigurationVariables(mediaInfo)
+
+			_, err := conf.ParseString(script)
+			assert.Nil(t, err)
+		})
+	}
+}


### PR DESCRIPTION
Allows us to use variables derived from the source input like `$source_width`, `$source_height`