### PR TITLE
Add flexible-enough support for download from and uploading to arbitrary URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ go test ./...
 
 - [x] parse a format like `mp4:1080p:mp3:2pass` into something machine-readable
 - [ ] when given this basic parsed format, some secondary options, and a source video URL, convert the source video into the target format
-- [ ] when given a source video url, download it
+- [x] when given an HTTP(S) source video url, download it
 - [x] when given a source video path, extract metadata like width, length, etc: [mediainfo](mediainfo)
 - [x] parse a config file into something machine-readable
 - [x] shove source video metadata into config file vars
@@ -33,5 +33,6 @@ go test ./...
 - [ ] post with-metadata and without-metadata webhooks on state changes
 - [ ] upload to S3 when given a file and an S3 url like `s3://access:secret@bucket/video.mp4`
 - [ ] also handle "unofficial" S3-compatible services like Minio
+- [ ] download from and upload to FTP, SFTP locations
 - [ ] output thumbnails using format `-> jpg:300x = $base_s3/thumbnail_small_#num#.jpg, number=6`
 - [ ] WebVTT thumbnails/metadata

--- a/files/download.go
+++ b/files/download.go
@@ -1,0 +1,23 @@
+package files
+
+import (
+	"fmt"
+
+	"github.com/AlbinoDrought/creamy-transcode/files/drivers/driver"
+	"github.com/AlbinoDrought/creamy-transcode/files/drivers/http"
+)
+
+var downloadDrivers = []driver.DownloadDriver{
+	http.Driver{},
+}
+
+// Download a file from the remote source to the local destination
+func Download(source string, dest string) error {
+	for _, downloadDriver := range downloadDrivers {
+		if downloadDriver.Handles(source) {
+			return downloadDriver.Download(source, dest)
+		}
+	}
+
+	return fmt.Errorf("unhandled source type: %v", source)
+}

--- a/files/drivers/driver/README.md
+++ b/files/drivers/driver/README.md
@@ -1,0 +1,7 @@
+# creamy-transcode/files/drivers/driver
+
+Driver interfaces that allow downloading from some source to a local destination,
+and uploading from some local source to some destination.
+
+If a Driver can `Handle` a path, it can be used to `Upload` to it or `Download` from it,
+depending if it is a `DownloadDriver`, and `UploadDriver`, or both.

--- a/files/drivers/driver/driver.go
+++ b/files/drivers/driver/driver.go
@@ -1,0 +1,18 @@
+package driver
+
+// A PathHandler determines if it can handle some arbitrary path
+type PathHandler interface {
+	Handles(path string) bool
+}
+
+// A DownloadDriver does the heavy lifting of actually downloading things
+type DownloadDriver interface {
+	PathHandler
+	Download(source string, dest string) error
+}
+
+// An UploadDriver does the heavy lifting of actually uploading things
+type UploadDriver interface {
+	PathHandler
+	Upload(source string, dest string) error
+}

--- a/files/drivers/http/README.md
+++ b/files/drivers/http/README.md
@@ -1,0 +1,127 @@
+# creamy-transcode/files/drivers/http
+
+HTTP Driver that allows downloading from remote HTTP sources and uploading
+to remote HTTP destinations.
+
+## Usage
+
+### Download
+
+```golang
+err := driver.Download("https://albinodrought.com/", "hi.html")
+```
+
+### Upload
+
+Files are POSTed to the given URL under the FormData key `file`.
+
+To change this, use the `http_file_name` query parameter.
+
+```golang
+// default formdata key
+err := driver.Upload("hi.html", "https://albinodrought.com/")
+
+// custom formdata key
+err := driver.Upload("hi.html", "https://albinodrought.com/?http_file_name=encoded_video")
+```
+
+## Example
+
+```golang
+package main
+
+import (
+	"log"
+
+	"github.com/AlbinoDrought/creamy-transcode/files/drivers/http"
+	"github.com/imroc/req"
+)
+
+func main() {
+	req.Debug = true
+
+	driver := http.Driver{}
+
+	err := driver.Download("https://albinodrought.com/", "hi.html")
+	if err != nil {
+		log.Fatalf("failed to download: %v", err)
+	}
+
+	err = driver.Upload("hi.html", "https://albinodrought.com/")
+	if err != nil {
+		log.Fatalf("failed to upload: %v", err)
+	}
+
+	err = driver.Upload("hi.html", "https://albinodrought.com/?http_file_name=honey")
+	if err != nil {
+		log.Fatalf("failed to upload with different key: %v", err)
+	}
+}
+
+// Output: (the 405 responses are because albinodrought.com doesn't accept POST requests)
+/*
+POST / HTTP/1.1
+Host: albinodrought.com
+User-Agent: Go-http-client/1.1
+Transfer-Encoding: chunked
+Content-Type: multipart/form-data; boundary=15c3dc206cd19609cb2c69111093795ae2ea8264593ec8685f62972b4d16
+Accept-Encoding: gzip
+
+--1ba46da54b9bdfa9c4ff22b04cb1d5058c13decedddf416ca11f301e1c20
+Content-Disposition: form-data; name="file"; filename="hi.html"
+Content-Type: application/octet-stream
+
+******
+--1ba46da54b9bdfa9c4ff22b04cb1d5058c13decedddf416ca11f301e1c20--
+
+
+=================================
+
+HTTP/1.1 405 Not Allowed
+Content-Length: 157
+Content-Type: text/html
+Date: Thu, 28 Mar 2019 05:15:23 GMT
+Server: nginx/1.15.9
+Strict-Transport-Security: max-age=16000000
+
+<html>
+<head><title>405 Not Allowed</title></head>
+<body>
+<center><h1>405 Not Allowed</h1></center>
+<hr><center>nginx/1.15.9</center>
+</body>
+</html>
+
+POST /?http_file_name=honey HTTP/1.1
+Host: albinodrought.com
+User-Agent: Go-http-client/1.1
+Transfer-Encoding: chunked
+Content-Type: multipart/form-data; boundary=1dd1a1cf77ff01136a184a55982a5603ffd8c7cffa202b616a47f3515995
+Accept-Encoding: gzip
+
+--2b37ce6cd7bcebacfed0a5c84b0d3a512a6516bd379db42656806a7c6dfb
+Content-Disposition: form-data; name="honey"; filename="hi.html"
+Content-Type: application/octet-stream
+
+******
+--2b37ce6cd7bcebacfed0a5c84b0d3a512a6516bd379db42656806a7c6dfb--
+
+
+=================================
+
+HTTP/1.1 405 Not Allowed
+Content-Length: 157
+Content-Type: text/html
+Date: Thu, 28 Mar 2019 05:15:23 GMT
+Server: nginx/1.15.9
+Strict-Transport-Security: max-age=16000000
+
+<html>
+<head><title>405 Not Allowed</title></head>
+<body>
+<center><h1>405 Not Allowed</h1></center>
+<hr><center>nginx/1.15.9</center>
+</body>
+</html>
+*/
+```

--- a/files/drivers/http/driver.go
+++ b/files/drivers/http/driver.go
@@ -1,0 +1,95 @@
+package http
+
+import (
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"path"
+	"strings"
+
+	"github.com/imroc/req"
+	"github.com/pkg/errors"
+)
+
+// uploadFormDataName is the default key used when no other is given
+const uploadFormDataName = "file"
+
+// uploadParameterFormDataName is the name of the query parameter that
+// overrides the default form data key.
+//
+// example url:
+//
+// 	https://albinodrought.com/something?http_file_name=foo
+//  - file would be uploaded under the key "foo"
+//
+// https://albinodrought.com/something
+// - file would be uploaded under the default key (uploadFormDataName const)
+const uploadParameterFormDataName = "http_file_name"
+
+// Driver handles downloading of files from HTTP sources
+type Driver struct{}
+
+// Handles returns true if the path is an HTTP resource
+func (driver Driver) Handles(path string) bool {
+	return strings.Index(path, "http://") == 0 || strings.Index(path, "https://") == 0
+}
+
+// Download the file from some HTTP source to a local destination
+func (driver Driver) Download(source string, dest string) error {
+	resp, err := http.Get(source)
+	if err != nil {
+		return errors.Wrapf(err, "error getting source %v", source)
+	}
+	defer resp.Body.Close()
+
+	out, err := os.Create(dest)
+	if err != nil {
+		return errors.Wrapf(err, "error creating local file %v", dest)
+	}
+	defer out.Close()
+
+	_, err = io.Copy(out, resp.Body)
+	if err != nil {
+		return errors.Wrap(err, "error copying response to created local file")
+	}
+
+	return nil
+}
+
+// Upload the file from a local source to some HTTP destination
+func (driver Driver) Upload(source string, dest string) error {
+	parsedURL, err := url.Parse(dest)
+	if err != nil {
+		return errors.Wrapf(err, "unable to parse destination url %v", dest)
+	}
+
+	formDataName := uploadFormDataName
+
+	// allow orverriding formdata name with "http_file_name" param in url
+	if override := parsedURL.Query().Get(uploadParameterFormDataName); override != "" {
+		formDataName = override
+	}
+
+	file, err := os.Open(source)
+	if err != nil {
+		return errors.Wrapf(err, "unable to open local source %v", source)
+	}
+	defer file.Close()
+
+	// actually upload our file
+	_, err = req.Post(
+		dest,
+		req.FileUpload{
+			File:      file,
+			FieldName: formDataName,
+			FileName:  path.Base(source),
+		},
+	)
+
+	if err != nil {
+		return errors.Wrap(err, "unable to upload file to destination")
+	}
+
+	return nil
+}

--- a/files/drivers/http/driver_test.go
+++ b/files/drivers/http/driver_test.go
@@ -1,0 +1,190 @@
+package http
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/imroc/req"
+
+	"github.com/AlbinoDrought/creamy-transcode/files/drivers/driver"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHandles(t *testing.T) {
+	cases := []struct {
+		path    string
+		handles bool
+	}{
+		{
+			"",
+			false,
+		},
+		{
+			"C:\\Windows\\System32\\drivers\\etc\\hosts",
+			false,
+		},
+		{
+			"ftp://albinodrought.com/hueg.jpg",
+			false,
+		},
+		{
+			"http://albinodrought.com/",
+			true,
+		},
+		{
+			"https://say.hi.to.albinodrought.com/some?good=stuff%20here",
+			true,
+		},
+	}
+
+	for _, c := range cases {
+		var name string
+		if c.handles {
+			name = fmt.Sprintf("should handle '%v'", c.path)
+		} else {
+			name = fmt.Sprintf("shouldn't handle '%v'", c.path)
+		}
+
+		t.Run(name, func(t *testing.T) {
+			driver := Driver{}
+			assert.Equal(t, c.handles, driver.Handles(c.path))
+		})
+	}
+}
+
+// should be a DownloadDriver
+var _ driver.DownloadDriver = Driver{}
+
+func TestDownload(t *testing.T) {
+	expected := []byte("hello world")
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write(expected)
+	}))
+	defer ts.Close()
+
+	dir, err := ioutil.TempDir("", "httpDriver_TestDownload")
+	assert.Nil(t, err)
+
+	defer os.RemoveAll(dir)
+
+	parsedURL, _ := url.Parse(ts.URL)
+	parsedURL.User = url.UserPassword("foo", "bar")
+	parsedURL.Path = "cream.txt?X-Access-Token=double-deluxe"
+
+	source := parsedURL.String()
+	dest := path.Join(dir, "foo.txt")
+
+	driver := Driver{}
+	err = driver.Download(source, dest)
+	assert.Nil(t, err)
+
+	contents, err := ioutil.ReadFile(dest)
+	assert.Nil(t, err)
+
+	assert.Equal(t, expected, contents)
+}
+
+// should be an UploadDriver
+var _ driver.UploadDriver = Driver{}
+
+func TestUpload(t *testing.T) {
+	req.Debug = true
+	cases := []struct {
+		bytes       []byte
+		filename    string
+		httpPath    string
+		formFileKey string
+	}{
+		{
+			[]byte("i am a talking computer"),
+			"sentience.txt",
+			"foo",
+			"file",
+		},
+		{
+			[]byte("i am a walking computer"),
+			"revolution.txt",
+			"bar?http_file_name=thestuff",
+			"thestuff",
+		},
+	}
+
+	for i, c := range cases {
+		si := strconv.Itoa(i)
+		t.Run("upload case #"+si, func(t *testing.T) {
+			// hack to wait for dummy server to receive request before leaving testcase
+			receivedRequest := make(chan bool, 1)
+
+			// boot up a thicc dummy server to receive and actually check uploads
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				defer func() {
+					// allow testcase to finish
+					receivedRequest <- true
+				}()
+
+				// make sure the path+query is correct
+				assert.Truef(
+					t,
+					strings.HasSuffix(r.URL.String(), c.httpPath),
+					"URL should end with %v",
+					c.httpPath,
+				)
+
+				// check if the file is actually posted
+				file, fileHeader, err := r.FormFile(c.formFileKey)
+				assert.Nil(t, err)
+				if err != nil {
+					// prevent test from complete explosion
+					return
+				}
+
+				// prevent leaving files on disk
+				defer r.MultipartForm.RemoveAll()
+
+				// ensure proper filename was sent
+				assert.Equal(t, c.filename, fileHeader.Filename)
+
+				// ensure proper bytes were sent
+				receivedBytes, err := ioutil.ReadAll(file)
+				assert.Nil(t, err)
+				assert.Equal(t, c.bytes, receivedBytes)
+			}))
+			defer ts.Close()
+
+			// create dummy folder to store fixtures
+			dir, err := ioutil.TempDir("", "httpDriver_TestUpload_"+si)
+			assert.Nil(t, err)
+
+			defer os.RemoveAll(dir)
+
+			source := path.Join(dir, c.filename)
+			dest := ts.URL + "/" + c.httpPath
+
+			// dump the actual fixture to disk
+			err = ioutil.WriteFile(source, c.bytes, os.ModePerm)
+			assert.Nil(t, err)
+
+			// attempt the upload
+			driver := Driver{}
+			err = driver.Upload(source, dest)
+			assert.Nil(t, err)
+
+			select {
+			case <-receivedRequest:
+				return
+			case <-time.After(3 * time.Second):
+				t.Fatal("no upload request received after 3s")
+			}
+		})
+	}
+}

--- a/files/upload.go
+++ b/files/upload.go
@@ -1,0 +1,23 @@
+package files
+
+import (
+	"fmt"
+
+	"github.com/AlbinoDrought/creamy-transcode/files/drivers/driver"
+	"github.com/AlbinoDrought/creamy-transcode/files/drivers/http"
+)
+
+var uploadDrivers = []driver.UploadDriver{
+	http.Driver{},
+}
+
+// Upload a file from the local source to the remote destination
+func Upload(source string, dest string) error {
+	for _, uploadDriver := range uploadDrivers {
+		if uploadDriver.Handles(dest) {
+			return uploadDriver.Upload(source, dest)
+		}
+	}
+
+	return fmt.Errorf("unhandled destination type: %v", source)
+}


### PR DESCRIPTION
Went for a simple interface: no streams, no driver backend mishmash, nothing. At this time I've only implemented an HTTP driver.

Main things are:

- All driver types decide if they `Handle` some URL. An HTTP driver would handle URLs like `http://albinodrought.com`, while an S3 driver would handle urls like `s3://accesskey:secretkey@some-bucket/some-path`
- Drivers that can download things (`DownloadDriver`) can download some file from a remote source to a local destination
- Drivers that can upload things (`UploadDriver`) can upload some file from a local source to a remote destination

When I use "local" here, I mean a file on the local filesystem. FUSE, some file in a mounted volume, a real :tm: file, doesn't matter - anything that can be used with the built-in `os` funcs. I think this will help reduce complexity, compared to an implementation that just passed streams around.