### PR TITLE
Feature: parse output URL options for later use

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,11 +28,12 @@ go test ./...
 - [x] when given a source video path, extract metadata like width, length, etc: [mediainfo](mediainfo)
 - [x] parse a config file into something machine-readable
 - [x] shove source video metadata into config file vars
+- [x] somehow parse "secondary url options" like `, metadata=true`, `, number=6`, etc
+- [ ] actually handle these parsed "secondary url options"
 - [ ] working `if` statements in config file
-- [ ] somehow handle "secondary url options" like `, metadata=true`, `, number=6`, etc
+- [ ] output thumbnails using format `-> jpg:300x = $base_s3/thumbnail_small_#num#.jpg, number=6`
 - [ ] post with-metadata and without-metadata webhooks on state changes
 - [ ] upload to S3 when given a file and an S3 url like `s3://access:secret@bucket/video.mp4`
 - [ ] also handle "unofficial" S3-compatible services like Minio
 - [ ] download from and upload to FTP, SFTP locations
-- [ ] output thumbnails using format `-> jpg:300x = $base_s3/thumbnail_small_#num#.jpg, number=6`
 - [ ] WebVTT thumbnails/metadata

--- a/conf/parse.go
+++ b/conf/parse.go
@@ -9,10 +9,15 @@ import (
 	"strings"
 )
 
+type ParsedOutput struct {
+	URL     string
+	Options map[string]string
+}
+
 type ParsedConf struct {
 	SourceURL  string
 	WebhookURL string
-	Outputs    map[string]string
+	Outputs    map[string]ParsedOutput
 }
 
 type parseContext struct {
@@ -57,7 +62,7 @@ func trimWhitespace(line string) string {
 func Parse(reader io.Reader) (ParsedConf, error) {
 	parseContext := &parseContext{
 		conf: ParsedConf{
-			Outputs: make(map[string]string),
+			Outputs: make(map[string]ParsedOutput),
 		},
 		variables:           make(map[string]string),
 		sortedVariableNames: []string{},

--- a/conf/parse_test.go
+++ b/conf/parse_test.go
@@ -128,7 +128,7 @@ func TestParseString(t *testing.T) {
 			`,
 			expected: ParsedConf{
 				SourceURL: "http://bar.com",
-				Outputs:   map[string]string{},
+				Outputs:   map[string]ParsedOutput{},
 			},
 		},
 		{
@@ -142,7 +142,7 @@ func TestParseString(t *testing.T) {
 			`,
 			expected: ParsedConf{
 				SourceURL: "http://bar.com",
-				Outputs:   map[string]string{},
+				Outputs:   map[string]ParsedOutput{},
 			},
 		},
 		{
@@ -156,7 +156,7 @@ func TestParseString(t *testing.T) {
 			`,
 			expected: ParsedConf{
 				WebhookURL: "barbarbarbarbarbarbarbarbarbarbarbarbarbarbarbar",
-				Outputs:    map[string]string{},
+				Outputs:    map[string]ParsedOutput{},
 			},
 		},
 		{
@@ -177,7 +177,7 @@ func TestParseString(t *testing.T) {
 			`,
 			expected: ParsedConf{
 				SourceURL: "notbar",
-				Outputs:   map[string]string{},
+				Outputs:   map[string]ParsedOutput{},
 			},
 		},
 		{
@@ -197,8 +197,13 @@ func TestParseString(t *testing.T) {
 			-> jpg:300x = $destination/thumbnail_small_#num#.jpg, number=$thumbnails
 			`,
 			expected: ParsedConf{
-				Outputs: map[string]string{
-					"jpg:300x": "s3://foo:bar@bucket/thumbnail_small_#num#.jpg, number=12",
+				Outputs: map[string]ParsedOutput{
+					"jpg:300x": ParsedOutput{
+						URL: "s3://foo:bar@bucket/thumbnail_small_#num#.jpg",
+						Options: map[string]string{
+							"number": "12",
+						},
+					},
 				},
 			},
 		},
@@ -228,12 +233,35 @@ func TestParseString(t *testing.T) {
 			expected: ParsedConf{
 				SourceURL:  "https://creamy-videos.internal.albinodrought.com/static/videos/5678/video",
 				WebhookURL: "https://creamy-videos.internal.albinodrought.com/api/video/5678/transcoded, metadata=true",
-				Outputs: map[string]string{
-					"webm":     "s3://some-s3-key:some-s3-secret@some-s3-bucket/videos/5678/transcode/video.webm",
-					"mp4":      "s3://some-s3-key:some-s3-secret@some-s3-bucket/videos/5678/transcode/video.mp4",
-					"mp4:720p": "s3://some-s3-key:some-s3-secret@some-s3-bucket/videos/5678/transcode/video_720p.mp4, if=$source_width >= 1280",
-					"jpg:300x": "s3://some-s3-key:some-s3-secret@some-s3-bucket/videos/5678/transcode/thumbnail_small_#num#.jpg, number=6",
-					"jpg:160x": "s3://some-s3-key:some-s3-secret@some-s3-bucket/videos/5678/transcode/thumbnail_sprite.jpg, every=5, sprite=yes, vtt=yes",
+				Outputs: map[string]ParsedOutput{
+					"webm": ParsedOutput{
+						URL:     "s3://some-s3-key:some-s3-secret@some-s3-bucket/videos/5678/transcode/video.webm",
+						Options: map[string]string{},
+					},
+					"mp4": ParsedOutput{
+						URL:     "s3://some-s3-key:some-s3-secret@some-s3-bucket/videos/5678/transcode/video.mp4",
+						Options: map[string]string{},
+					},
+					"mp4:720p": ParsedOutput{
+						URL: "s3://some-s3-key:some-s3-secret@some-s3-bucket/videos/5678/transcode/video_720p.mp4",
+						Options: map[string]string{
+							"if": "$source_width >= 1280",
+						},
+					},
+					"jpg:300x": ParsedOutput{
+						URL: "s3://some-s3-key:some-s3-secret@some-s3-bucket/videos/5678/transcode/thumbnail_small_#num#.jpg",
+						Options: map[string]string{
+							"number": "6",
+						},
+					},
+					"jpg:160x": ParsedOutput{
+						URL: "s3://some-s3-key:some-s3-secret@some-s3-bucket/videos/5678/transcode/thumbnail_sprite.jpg",
+						Options: map[string]string{
+							"every":  "5",
+							"sprite": "yes",
+							"vtt":    "yes",
+						},
+					},
 				},
 			},
 		},


### PR DESCRIPTION
Output urls that look like this:

`-> jpg:300x = $destination/thumbnail_small_#num#.jpg, number=12`

are now parsed into:

```golang
ParsedConf{
	Outputs: map[string]ParsedOutput{
		"jpg:300x": ParsedOutput{
			URL: "s3://foo:bar@bucket/thumbnail_small_#num#.jpg",
			Options: map[string]string{
				"number": "12",
			},
		},
	},
},
```

This PR does not implement any actual handling of these options.

---

This PR completes the 
```
[x] somehow parse "secondary url options" like `, metadata=true`, `, number=6`, etc
```
item, but adds another one: `[ ] actually handle these parsed "secondary url options"`.